### PR TITLE
Fixed FanIn/Out-Operator and SampleNRandomOperator

### DIFF
--- a/csa/_elementary.py
+++ b/csa/_elementary.py
@@ -135,7 +135,7 @@ class SampleNRandomMask (cs.Finite,cs.Mask):
                 seed = state['seed']
             else:
                 seed = 'SampleNRandomMask'
-            numpy.random.seed (hash (seed))
+            numpy.random.seed (abs (hash (seed)) % numpy.iinfo(numpy.int32).max*2)
             
             N = numpy.random.multinomial (self.N, numpy.array (sizes) \
                                            / float (total))
@@ -243,7 +243,7 @@ class FanInRandomMask (cs.Finite, cs.Mask):
             else:
                 seed = 'FanInRandomMask'
             # Numpy.random.seed requires unsigned integer
-            numpy.random.seed (abs (hash (seed)))
+            numpy.random.seed (abs (hash (seed)) % numpy.iinfo(numpy.int32).max*2)
 
             selected = state['selected']
             obj.mask = partitions[selected]

--- a/csa/_elementary.py
+++ b/csa/_elementary.py
@@ -135,8 +135,8 @@ class SampleNRandomMask (cs.Finite,cs.Mask):
                 seed = state['seed']
             else:
                 seed = 'SampleNRandomMask'
-            numpy.random.seed (abs (hash (seed)) % numpy.iinfo(numpy.int32).max*2)
-            
+            # Numpy requires an unsigned 32-bit integer
+            numpy.random.seed (hash (seed) % (numpy.iinfo(numpy.uint32).max + 1))
             N = numpy.random.multinomial (self.N, numpy.array (sizes) \
                                            / float (total))
             obj.N = N[state['selected']]
@@ -242,8 +242,8 @@ class FanInRandomMask (cs.Finite, cs.Mask):
                 seed = state['seed']
             else:
                 seed = 'FanInRandomMask'
-            # Numpy.random.seed requires unsigned integer
-            numpy.random.seed (abs (hash (seed)) % numpy.iinfo(numpy.int32).max*2)
+            # Numpy.random.seed requires an unsigned 32 bit integer
+            numpy.random.seed (hash (seed) % (numpy.iinfo(numpy.uint32).max + 1))
 
             selected = state['selected']
             obj.mask = partitions[selected]


### PR DESCRIPTION
This commit fixes the FanInOperator, FanOutOperator and SampleNOperator failing when generating connections from their respective iterators on 64-bit python builds.
When generating the iterator, the numpy random function was seeded using a hash function. This hash function would generate a 64-bit integer on 64-bit python builds, while numpy.random.seed() only takes 32-bit integers. This caused the iterator generation to fail without error messages, as the function was being called from pycsa.cpp.

This is fixed in this commit by limiting the returned hash to a 32-bit integer using modulo.