### PR TITLE
Allow out-of-source-compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+Makefile.in
+aclocal.m4
+autom4te.cache
+compile
+config.guess
+config.h.in
+config.sub
+configure
+*.pyc
+depcomp
+fontList.cache
+install-sh
+ltmain.sh
+missing

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-Makefile.in
+*.pyc
 aclocal.m4
 autom4te.cache
 compile
@@ -6,9 +6,11 @@ config.guess
 config.h.in
 config.sub
 configure
-*.pyc
 depcomp
+dist
 fontList.cache
 install-sh
 ltmain.sh
+Makefile.in
+MANIFEST
 missing

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,7 +1,7 @@
 SUBDIRS = @LIBPYCSA_SUBDIR@
 
 PACKAGE_NAME = python-csa
-PACKAGE_VERSION = $(shell python -c 'from csa.version import __version__; print __version__')
+PACKAGE_VERSION = $(shell PYTHONPATH=$(srcdir) python -c 'from csa.version import __version__; print __version__')
 
 debdir = dist/csa-$(PACKAGE_VERSION)
 
@@ -21,6 +21,7 @@ debian-package: debian-source
 	( cd $(debdir) && dpkg-buildpackage '-mMikael Djurfeldt <mdj@debian.org>' -rfakeroot && cd ../.. && rm -rf $(debdir) )
 
 install-exec-hook:
+	cd $(srcdir) &&\
 	$(PYTHON) setup.py build --build-base=$(abs_builddir)/build install --prefix=$(DESTDIR)$(prefix) --install-lib=$(DESTDIR)$(pyexecdir) --install-scripts=$(DESTDIR)$(bindir) --install-data=$(DESTDIR)$(pkgdatadir)
 
 clean-local:


### PR DESCRIPTION
This PR adds a basic `.gitignore` file and modifies `Makefile.am` to allow out-of-source builds.

Please note that the `make dist` target was not altered as that seems to be broken. See #3 for a corresponding issue.