### PR TITLE
Fix: Add missing __init__.py to fix installation and tests on Python 3

### DIFF
--- a/csa/__init__.py
+++ b/csa/__init__.py
@@ -1,0 +1,36 @@
+#
+#  This file is part of the Connection-Set Algebra (CSA).
+#  Copyright (C) 2010,2011,2012,2017 Mikael Djurfeldt
+#
+#  CSA is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  CSA is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import ctypes
+try:
+    _libpycsa_handle_ = ctypes.CDLL ('@libdir@/libpycsa.so')
+except OSError:
+    None
+
+from .version import __version__
+from .connset import Mask
+from .connset import ConnectionSet
+from .elementary import *
+#from operators import *
+#from arithmetic import *
+from .misc import *
+from .geometry import *
+from .csaobject import parse, from_xml
+from .plot import *
+from .closure import *
+from .conngen import *


### PR DESCRIPTION
### Problem
The package was failing to install correctly via `pip install .` on environments where the `configure` script is not run (e.g., standard Python/pip workflows or Windows). This caused `csa` to be treated as an empty namespace package, leading to `NameError` failures in the test suite because symbols like `cross` and `full` were not exported.

### Solution
Manually added `csa/__init__.py` (based on `csa/__init__.py.in`) to ensure the package initializes correctly and exports all necessary modules.

### Verification
Ran the test suite locally on Python 3.11:
**Before Fix:**
`FAILED (errors=9)` - All tests crashed with `NameError`.

**After Fix:**
`Ran 9 tests in 6.702s`
`OK`